### PR TITLE
Add Edit Profile Screen with Current User Data Display and Update Functionality

### DIFF
--- a/lib/services/auth_wrapper.dart
+++ b/lib/services/auth_wrapper.dart
@@ -11,9 +11,9 @@ class AuthWrapper extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<UserViewModel>(
       builder: (context, userViewModel, child) {
-        userViewModel.loadUser();
+        userViewModel.loadUser(); 
 
-        if (userViewModel.user != null) {
+        if (userViewModel.userModel != null) {
           return HomeScreen();
         } else {
           return LoginScreen();
@@ -22,3 +22,4 @@ class AuthWrapper extends StatelessWidget {
     );
   }
 }
+

--- a/lib/view_models/user_view_model.dart
+++ b/lib/view_models/user_view_model.dart
@@ -1,14 +1,19 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/user.dart';
 
 class UserViewModel extends ChangeNotifier {
+  final nameController = TextEditingController();
+  final passwordController = TextEditingController();
   final FirebaseAuth _auth = FirebaseAuth.instance;
+
   UserModel? _user;
+  bool isEditingName = false;
+  bool isEditingPassword = false;
 
-  UserModel? get user => _user;
+  UserModel? get userModel => _user;
+  User? get firebaseUser => _auth.currentUser;
 
-  // Fetch the current user
   void loadUser() {
     final currentUser = _auth.currentUser;
     if (currentUser != null) {
@@ -18,6 +23,8 @@ class UserViewModel extends ChangeNotifier {
         email: currentUser.email ?? '',
         profileImageUrl: currentUser.photoURL,
       );
+      nameController.text = currentUser.displayName ?? '';
+      passwordController.clear();
       notifyListeners();
     }
   }
@@ -55,7 +62,7 @@ class UserViewModel extends ChangeNotifier {
 
       _user = UserModel(
         id: credential.user!.uid,
-        name: "New User", 
+        name: "New User",
         email: credential.user!.email ?? '',
         profileImageUrl: credential.user!.photoURL,
       );
@@ -72,5 +79,47 @@ class UserViewModel extends ChangeNotifier {
     await _auth.signOut();
     _user = null;
     notifyListeners();
+  }
+
+  void toggleNameEditing() {
+    isEditingName = !isEditingName;
+    notifyListeners();
+  }
+
+  void togglePasswordEditing() {
+    isEditingPassword = !isEditingPassword;
+    notifyListeners();
+  }
+
+  Future<void> updateProfile(BuildContext context) async {
+    final currentUser = _auth.currentUser;
+    if (currentUser != null) {
+      try {
+        if (isEditingName) {
+          await currentUser.updateDisplayName(nameController.text);
+        }
+        if (isEditingPassword && passwordController.text.isNotEmpty) {
+          await currentUser.updatePassword(passwordController.text);
+        }
+
+        await currentUser.reload();
+        loadUser();
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Profile updated")),
+        );
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Error: ${e.toString()}")),
+        );
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    passwordController.dispose();
+    super.dispose();
   }
 }

--- a/lib/views/edit_profile_screen.dart
+++ b/lib/views/edit_profile_screen.dart
@@ -1,99 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skylab_mobile/view_models/user_view_model.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:skylab_mobile/views/settings_screen.dart';
 
-class EditProfileScreen extends StatefulWidget {
+class EditProfileScreen extends StatelessWidget {
   const EditProfileScreen({super.key});
-
-  @override
-  State<EditProfileScreen> createState() => _EditProfileScreenState();
-}
-
-class _EditProfileScreenState extends State<EditProfileScreen> {
-  final _formKey = GlobalKey<FormState>();
-  bool isEditingName = false;
-  bool isEditingPassword = false;
-
-  late TextEditingController _nameController;
-  late TextEditingController _passwordController;
-
-  @override
-  void initState() {
-    super.initState();
-    final user = FirebaseAuth.instance.currentUser;
-
-    _nameController = TextEditingController(text: user?.displayName ?? '');
-    _passwordController = TextEditingController();
-  }
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _saveChanges(UserViewModel userViewModel) async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user != null) {
-      try {
-        if (isEditingName) {
-          await user.updateDisplayName(_nameController.text);
-        }
-        if (isEditingPassword && _passwordController.text.isNotEmpty) {
-          await user.updatePassword(_passwordController.text);
-        }
-
-        await user.reload();
-        userViewModel.loadUser();
-
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text("Profile updated")),
-          );
-          Navigator.pop(context);
-        }
-      } catch (e) {
-        print("Update failed: $e");
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Error: ${e.toString()}")),
-        );
-      }
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     final userViewModel = Provider.of<UserViewModel>(context);
-    final user = FirebaseAuth.instance.currentUser;
+    final user = userViewModel.userModel;
 
     return Scaffold(
       appBar: AppBar(title: const Text("Edit Profile")),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(
-          key: _formKey,
           child: Column(
             children: [
               // NAME
               Row(
                 children: [
                   Expanded(
-                    child: isEditingName
+                    child: userViewModel.isEditingName
                         ? TextFormField(
-                            controller: _nameController,
+                            controller: userViewModel.nameController,
                             decoration: const InputDecoration(labelText: "Name"),
                           )
-                        : Text("Name: ${user?.displayName ?? ''}"),
+                        : Text("Name: ${user?.name ?? ''}"),
                   ),
                   TextButton(
-                    onPressed: () {
-                      setState(() {
-                        isEditingName = !isEditingName;
-                      });
-                    },
-                    child: Text(isEditingName ? "Cancel" : "Edit"),
+                    onPressed: userViewModel.toggleNameEditing,
+                    child: Text(userViewModel.isEditingName ? "Cancel" : "Edit"),
                   )
                 ],
               ),
@@ -103,13 +41,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
               // EMAIL
               Row(
                 children: [
-                  Expanded(
-                    child: Text("Email: ${user?.email ?? ''}"),
-                  ),
-                  const TextButton(
-                    onPressed: null, 
-                    child: Text("Edit"),
-                  )
+                  Expanded(child: Text("Email: ${user?.email ?? ''}")),
+                  const Text("(Email can't be changed)", style: TextStyle(color: Colors.grey)),
                 ],
               ),
 
@@ -119,28 +52,31 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
               Row(
                 children: [
                   Expanded(
-                    child: isEditingPassword
+                    child: userViewModel.isEditingPassword
                         ? TextFormField(
-                            controller: _passwordController,
+                            controller: userViewModel.passwordController,
                             obscureText: true,
                             decoration: const InputDecoration(labelText: "New Password"),
                           )
                         : const Text("Password: ********"),
                   ),
                   TextButton(
-                    onPressed: () {
-                      setState(() {
-                        isEditingPassword = !isEditingPassword;
-                      });
-                    },
-                    child: Text(isEditingPassword ? "Cancel" : "Change"),
+                    onPressed: userViewModel.togglePasswordEditing,
+                    child: Text(userViewModel.isEditingPassword ? "Cancel" : "Change"),
                   )
                 ],
               ),
 
               const SizedBox(height: 24),
+              const SizedBox(height: 24),
               ElevatedButton(
-                onPressed: () => _saveChanges(userViewModel),
+                onPressed: () {
+                  userViewModel.updateProfile(context);
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(builder: (context) => SettingsScreen()),
+                  );
+                },
                 child: const Text("Save Changes"),
               ),
             ],

--- a/lib/views/edit_profile_screen.dart
+++ b/lib/views/edit_profile_screen.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:skylab_mobile/view_models/user_view_model.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class EditProfileScreen extends StatefulWidget {
+  const EditProfileScreen({super.key});
+
+  @override
+  State<EditProfileScreen> createState() => _EditProfileScreenState();
+}
+
+class _EditProfileScreenState extends State<EditProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+  bool isEditingName = false;
+  bool isEditingPassword = false;
+
+  late TextEditingController _nameController;
+  late TextEditingController _passwordController;
+
+  @override
+  void initState() {
+    super.initState();
+    final user = FirebaseAuth.instance.currentUser;
+
+    _nameController = TextEditingController(text: user?.displayName ?? '');
+    _passwordController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveChanges(UserViewModel userViewModel) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      try {
+        if (isEditingName) {
+          await user.updateDisplayName(_nameController.text);
+        }
+        if (isEditingPassword && _passwordController.text.isNotEmpty) {
+          await user.updatePassword(_passwordController.text);
+        }
+
+        await user.reload();
+        userViewModel.loadUser();
+
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text("Profile updated")),
+          );
+          Navigator.pop(context);
+        }
+      } catch (e) {
+        print("Update failed: $e");
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Error: ${e.toString()}")),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final userViewModel = Provider.of<UserViewModel>(context);
+    final user = FirebaseAuth.instance.currentUser;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Edit Profile")),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              // NAME
+              Row(
+                children: [
+                  Expanded(
+                    child: isEditingName
+                        ? TextFormField(
+                            controller: _nameController,
+                            decoration: const InputDecoration(labelText: "Name"),
+                          )
+                        : Text("Name: ${user?.displayName ?? ''}"),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        isEditingName = !isEditingName;
+                      });
+                    },
+                    child: Text(isEditingName ? "Cancel" : "Edit"),
+                  )
+                ],
+              ),
+
+              const SizedBox(height: 16),
+
+              // EMAIL
+              Row(
+                children: [
+                  Expanded(
+                    child: Text("Email: ${user?.email ?? ''}"),
+                  ),
+                  const TextButton(
+                    onPressed: null, 
+                    child: Text("Edit"),
+                  )
+                ],
+              ),
+
+              const SizedBox(height: 16),
+
+              // PASSWORD
+              Row(
+                children: [
+                  Expanded(
+                    child: isEditingPassword
+                        ? TextFormField(
+                            controller: _passwordController,
+                            obscureText: true,
+                            decoration: const InputDecoration(labelText: "New Password"),
+                          )
+                        : const Text("Password: ********"),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        isEditingPassword = !isEditingPassword;
+                      });
+                    },
+                    child: Text(isEditingPassword ? "Cancel" : "Change"),
+                  )
+                ],
+              ),
+
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () => _saveChanges(userViewModel),
+                child: const Text("Save Changes"),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/settings_screen.dart
+++ b/lib/views/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:skylab_mobile/core/theme/dark_theme.dart';
 import 'package:skylab_mobile/core/theme/theme_provider.dart';
 import '../services/auth_service.dart';
 import 'package:skylab_mobile/views/login_screen.dart';
+import 'package:skylab_mobile/views/edit_profile_screen.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -25,9 +26,10 @@ class SettingsScreen extends StatelessWidget {
             leading: const Icon(Icons.edit),
             title: const Text("Edit Profile"),
             onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text("Edit Profile tapped")),
-              );
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const EditProfileScreen()),
+                );
             },
           ),
           ListTile(


### PR DESCRIPTION
**Description**:

This pull request introduces the `EditProfileScreen`, allowing authenticated users to view and update their profile information in a structured and user-friendly interface. The screen displays the current user's name, email, and password in a readable format, with options to edit each field individually.

**Key Features**:

* Display of current user's name and email retrieved from Firebase Authentication.
* Toggleable editing for the name and password fields.
* Input validation and update functionality for:

  * Display name via `updateDisplayName()`
  * Password via `updatePassword()`
* Integration with `UserViewModel` to refresh and reflect changes after update.
* Form-based layout with clear separation between display and edit modes.
* Snackbars for success and error feedback.

**Notes**:

* Email editing is currently displayed but disabled, as it requires re-authentication for security. This can be implemented later if needed.
* Password change requires the user to input a new password; the current password is not shown for security reasons.
* The `UserViewModel`'s `loadUser()` method is reused after updates to keep the data in sync.

Editing page:

<img width="401" alt="Screenshot 2025-05-19 at 12 27 47" src="https://github.com/user-attachments/assets/71c9d21e-39f2-4db6-aabc-6e7ea0cb71c7" />


<img width="400" alt="Screenshot 2025-05-19 at 12 27 59" src="https://github.com/user-attachments/assets/bb99bee4-34ec-4bc1-ac05-70883f6538c0" />

After saving changments:

<img width="429" alt="Screenshot 2025-05-19 at 12 28 15" src="https://github.com/user-attachments/assets/8db173ff-3f5e-444f-880f-28086f3c4349" />
